### PR TITLE
Make DB a class instead of a singleton.

### DIFF
--- a/src/db.coffee
+++ b/src/db.coffee
@@ -3,51 +3,51 @@ fs = require 'fs'
 path = require 'path'
 spawn = require('child_process').spawn
 
-db =
-  REDIS_CONF_FILE: '../etc/redis.conf'
-  REDIS_PID_FILE: '/usr/local/var/run/redis-impromptu.pid'
-  REDIS_PORT: 6420
+class DB
+  @REDIS_CONF_FILE: '../etc/redis.conf'
+  @REDIS_PID_FILE: '/usr/local/var/run/redis-impromptu.pid'
+  @REDIS_PORT: 6420
 
   # Returns the connection to the Redis server.
   client: ->
     # If the client object isn't cached, create a new connection.
-    unless db._client
-      db._client = redis.createClient db.REDIS_PORT
+    unless @_client
+      @_client = redis.createClient DB.REDIS_PORT
 
       # If the client throws an error, attempt to spawn the Redis server.
       # The client will automatically attempt to reconnect, so if we
       # successfully start the server, things will proceed normally.
-      db._client.once 'error', db._spawnServerFromError
+      @_client.once 'error', @_spawnServerFromError
 
       # If the client connects error-free, ensure the error handler is removed.
-      db._client.on 'connect', ->
-        db._client.removeListener 'error', db._spawnServerFromError
+      @_client.on 'connect', =>
+        @_client.removeListener 'error', @_spawnServerFromError
 
-    db._client
+    @_client
 
   shutdown: ->
     # We don't use `@client()` here because we don't want to spawn the server
     # if it isn't already running.
     #
     # If we don't have a cached client, attempt to connect.
-    db._client = redis.createClient db.REDIS_PORT unless db._client
+    @_client = redis.createClient DB.REDIS_PORT unless @_client
 
     # Remove the error handler that will spawn the server.
-    db._client.removeListener 'error', db._spawnServerFromError
+    @_client.removeListener 'error', @_spawnServerFromError
 
     # Silently absorb any errors.
-    db._client.on 'error', ->
+    @_client.on 'error', ->
 
     # Shut down the server and gracefully disconnect.
-    db._client.shutdown()
-    db._client.quit()
+    @_client.shutdown()
+    @_client.quit()
 
   # Start the `redis-server` daemon if it doesn't already exist.
   _spawnServerFromError: (error) ->
     # If the server's PID file exists, check if it's accurate.
-    if fs.existsSync db.REDIS_PID_FILE
+    if fs.existsSync DB.REDIS_PID_FILE
       # Fetch the process ID.
-      pid = parseInt fs.readFileSync(db.REDIS_PID_FILE), 10
+      pid = parseInt fs.readFileSync(DB.REDIS_PID_FILE), 10
 
       # Attempt to ping the process.
       try
@@ -58,10 +58,10 @@ db =
       # If pinging the server throws an error (ESRCH), then we know the PID
       # file is inaccurate; remove it.
       catch ersch
-        fs.unlinkSync db.REDIS_PID_FILE
+        fs.unlinkSync DB.REDIS_PID_FILE
 
     # Spawn the server using the Impromptu server settings.
-    spawn 'redis-server', [path.resolve __dirname, db.REDIS_CONF_FILE]
+    spawn 'redis-server', [path.resolve __dirname, DB.REDIS_CONF_FILE]
 
-# Expose `db`.
-exports = module.exports = db
+# Expose `DB`.
+exports = module.exports = DB

--- a/src/impromptu.coffee
+++ b/src/impromptu.coffee
@@ -9,6 +9,7 @@ class Impromptu
   paths: "#{@CONFIG_DIR}/prompt.#{ext}" for ext in ['coffee', 'js']
 
   constructor: ->
+    @db = new Impromptu.DB
     @prompt = new Impromptu.Prompt
 
     configPath = _.find @paths, (path) ->
@@ -28,8 +29,8 @@ class Impromptu
 exports = module.exports = Impromptu
 
 # Expose APIs.
+exports.DB = require './db'
 exports.Prompt = require './prompt'
 exports.color = require './color'
-exports.db = require './db'
 exports.exec = require './exec'
 exports.module = require './module'

--- a/test/db.coffee
+++ b/test/db.coffee
@@ -8,9 +8,9 @@ exec = require('child_process').exec
 # Todo: Make these work
 return if process.env.TRAVIS is 'true'
 
-Impromptu.db.REDIS_PORT = 6421
-Impromptu.db.REDIS_CONF_FILE = '../test/etc/redis.conf'
-Impromptu.db.REDIS_PID_FILE = '/usr/local/var/run/redis-impromptu-test.pid'
+Impromptu.DB.REDIS_PORT = 6421
+Impromptu.DB.REDIS_CONF_FILE = '../test/etc/redis.conf'
+Impromptu.DB.REDIS_PID_FILE = '/usr/local/var/run/redis-impromptu-test.pid'
 
 describe 'Impromptu', ->
   it 'should exist', ->
@@ -20,7 +20,7 @@ describe 'Database', ->
   # Try to kill the server if it's running.
   before (done) ->
     # Check if the server is running.
-    path = Impromptu.db.REDIS_PID_FILE
+    path = Impromptu.DB.REDIS_PID_FILE
     return done() unless fs.existsSync path
 
     # Fetch the process ID and kill it.
@@ -28,14 +28,11 @@ describe 'Database', ->
     # Make it die a painful death.
     exec "kill -9 #{pid}", done
 
-  after ->
-    delete Impromptu.db._client
-
   it 'should exist', ->
-    should.exist Impromptu.db
+    should.exist Impromptu.DB
 
   it 'should be stopped', (done) ->
-    client = redis.createClient Impromptu.db.REDIS_PORT
+    client = redis.createClient Impromptu.DB.REDIS_PORT
 
     client.on 'error', ->
       client.quit()
@@ -49,7 +46,8 @@ describe 'Database', ->
       client.removeAllListeners()
 
   it 'should start', (done) ->
-    client = Impromptu.db.client()
+    db = new Impromptu.DB
+    client = db.client()
     client.on 'connect', ->
       client.quit()
       done()
@@ -65,8 +63,6 @@ describe 'Database', ->
         client.removeAllListeners
 
   it 'should stop', (done) ->
-    # TODO: This is a race condition, and should be fixed.
-    done() unless Impromptu.db._client.connected
-
-    Impromptu.db.client().on 'end', done
-    Impromptu.db.shutdown()
+    db = new Impromptu.DB
+    db.client().on 'end', done
+    db.shutdown()


### PR DESCRIPTION
This is more aligned with how we treat APIs (given that Impromptu is a class) and has the added benefit of making it easier to manage state in the database unit tests.
