### PR TITLE
Add a `disabled` parameter for disabling sections in prompt.coffee

### DIFF
--- a/src/prompt.coffee
+++ b/src/prompt.coffee
@@ -32,6 +32,7 @@ class Prompt
     # Create the section if it doesn't already exist.
     unless @_sections[key]
       @_sections[key] =
+        disabled: false
         background: 'default'
         foreground: 'default'
         options:
@@ -55,6 +56,8 @@ class Prompt
     # Apply changes to the section properties.
     _.extend section, properties
 
+    # if the section is disabled, we override `when`
+    section.when = [false] if properties.disabled?
 
   # Build the prompt.
   build: (fn) ->

--- a/test/prompt.coffee
+++ b/test/prompt.coffee
@@ -30,6 +30,11 @@ describe 'Prompt', ->
       content: 'd'
       background: 'red'
       foreground: 'white'
+    disabled:
+      content: "you should not see me"
+      disabled: yes
+      background: 'green'
+      foreground: 'white'
     empty:
       content: ''
       background: 'red'
@@ -112,4 +117,10 @@ describe 'Prompt', ->
     prompt = makePrompt ['format']
     prompt.build (err, result) ->
       result.should.equal expect.multi
+      done()
+
+  it 'should hide disabled sections', (done) ->
+    prompt = makePrompt ['b', 'disabled']
+    prompt.build (err, result) ->
+      result.should.equal expect.b
       done()


### PR DESCRIPTION
Yes, you could use `when`, but if you already have a `when`, that can be burdensome.
