### PR TITLE
Unreference the impromptu-background process.

### DIFF
--- a/bin/impromptu
+++ b/bin/impromptu
@@ -8,8 +8,9 @@ new Impromptu().prompt.build(function(err, results) {
 });
 
 // Spawn the background process to asynchronously update the cache.
-spawn(__dirname + '/impromptu-background', [], {
+background = spawn(__dirname + '/impromptu-background', [], {
   stdio: 'ignore',
   detached: true,
   cwd: process.cwd()
 });
+background.unref();


### PR DESCRIPTION
Marking impromptu-background as `detached` is not enough, we also have
to inform the parent process to remove it from its references.
