### PR TITLE
Do not store modules in the module registry.

### DIFF
--- a/src/module.coffee
+++ b/src/module.coffee
@@ -40,16 +40,9 @@ class _Method
 
 
 class _Module
-  constructor: (@impromptu, @moduleRegistry, initialize) ->
+  constructor: (@impromptu, initialize) ->
     @_methods = {}
     initialize.call @, Impromptu
-
-  name: (key) ->
-    return @_name unless key
-
-    @moduleRegistry.unset @_name
-    @_name = key
-    @moduleRegistry.set @_name, @_methods
 
   register: (key, options) ->
     method = new _Method @, key, options
@@ -67,24 +60,12 @@ class ModuleRegistry
 
   # Register a new Impromptu module.
   register: (fn) ->
-    new _Module(@impromptu, @, fn)._methods
+    new _Module(@impromptu, fn)._methods
 
   # Require and register a new Impromptu module.
   require: (module) ->
     fn = require "#{Impromptu.CONFIG_DIR}/node_modules/#{module}"
     @register fn if typeof fn == 'function'
-
-  # Get an existing Impromptu module.
-  get: (name) ->
-    @_modules[name]
-
-  # Set an existing Impromptu module.
-  set: (name, methods) ->
-    @_modules[name] = methods
-
-  # Unset an existing Impromptu module.
-  unset: (name) ->
-    delete @_modules[name]
 
 
 # Expose `ModuleRegistry`.

--- a/test/module.coffee
+++ b/test/module.coffee
@@ -9,8 +9,6 @@ describe 'Module', ->
 
   it 'should register a module', ->
     methods = impromptu.module.register ->
-      @name 'methods'
-
       @register 'hello',
         update: ->
           'Hello, world!'
@@ -24,9 +22,6 @@ describe 'Module', ->
           @exec 'echo test', done
 
     methods.should.have.keys 'hello', 'count', 'echo'
-
-  it 'should store a module', ->
-    impromptu.module.get('methods').should.equal methods
 
   it 'should call a method', ->
     methods.hello (err, results) ->


### PR DESCRIPTION
Removing names and module storage is useful, as a prompt and module X
may require different versions of module Y, and storage may create
conflicts.
