### PR TITLE
Break all the things!

### DIFF
--- a/src/module.coffee
+++ b/src/module.coffee
@@ -5,9 +5,9 @@ exec = require('child_process').exec
 class _Module
   constructor: (@impromptu, @factory, @name, initialize) ->
     @_methods = {}
-    initialize.call @, Impromptu, @_methods
+    initialize.call @impromptu, Impromptu, @register, @_methods
 
-  register: (key, options) ->
+  register: (key, options) =>
     # Cache responses using the instance cache by default.
     if typeof options.cache is 'undefined' or options.cache is true
       options.cache = 'instance'
@@ -16,17 +16,13 @@ class _Module
     # This won't cache the value, it just creates a consistent API.
     options.cache ||= 'shim'
 
-    options.context = @
+    # Set the impromptu instance as the context by default.
+    options.context ?= @impromptu
 
     Cache = @factory.cache[options.cache] || @factory.cache.instance
     cache = new Cache @impromptu, "#{@name}:#{key}", options
 
     @_methods[key] = cache.run
-
-  get: (key, fn) ->
-    @_methods[key] fn if @_methods[key]
-
-  exec: Impromptu.exec
 
 
 class ModuleFactory

--- a/test/etc/sample-configfile.coffee
+++ b/test/etc/sample-configfile.coffee
@@ -1,16 +1,16 @@
 module.exports = (Impromptu, section) ->
-  methods = @module.register 'sample-configfile', ->
-    @register 'cwd',
+  methods = @module.register 'sample-configfile', (Impromptu, register) ->
+    register 'cwd',
       update: (done) ->
-        @exec 'printf "~/path/to/impromptu"', done
+        Impromptu.exec 'printf "~/path/to/impromptu"', done
 
-    @register 'user',
+    register 'user',
       update: (done) ->
-        @exec 'printf "user"', done
+        Impromptu.exec 'printf "user"', done
 
-    @register 'host',
+    register 'host',
       update: (done) ->
-        @exec 'printf "host"', done
+        Impromptu.exec 'printf "host"', done
 
 
   section 'user',

--- a/test/module.coffee
+++ b/test/module.coffee
@@ -8,18 +8,18 @@ describe 'Module', ->
   counter = 0
 
   it 'should register a module', ->
-    methods = impromptu.module.register 'module-tests', ->
-      @register 'hello',
+    methods = impromptu.module.register 'module-tests', (Impromptu, register) ->
+      register 'hello',
         update: ->
           'Hello, world!'
 
-      @register 'count',
+      register 'count',
         update: ->
           counter += 1
 
-      @register 'echo',
+      register 'echo',
         update: (done) ->
-          @exec 'echo test', done
+          Impromptu.exec 'echo test', done
 
     methods.should.have.keys 'hello', 'count', 'echo'
 

--- a/test/prompt.coffee
+++ b/test/prompt.coffee
@@ -9,13 +9,13 @@ describe 'Prompt', ->
     'Hello, world!'
 
   # Note: All module methods are handled asynchronously.
-  methods = impromptu.module.register 'prompt-tests', ->
-    @register 'hello',
+  methods = impromptu.module.register 'prompt-tests', (Impromptu, register) ->
+    register 'hello',
       update: helloSync
 
-    @register 'echo',
+    register 'echo',
       update: (done) ->
-        @exec "printf test", done
+        Impromptu.exec "printf test", done
 
   sections =
     a:


### PR DESCRIPTION
**Remove backwards compatibility for passing a function to register.**

We left backwards compatibility in the register function to allow the API to evolve. We've now reached a point where it makes sense to break with that earlier functionality.

**Pass the module's methods to its initialize method.**

This allows modules to use their own methods in a similar way that the prompt file and other modules will use their APIs. Hopefully this will make module design a bit clearer (and less unweildy).

Some property locking is planned for a future commit.

**Revise and reduce the module API.**
- Removed the module's get and exec methods.
- Pass the module's `register` method to its `initialize` method.
- Run a module's `initialize` method with `@impromptu` as the context.
- Execute a method's `context` to `@impromptu` by default.
