### PR TITLE
Tell OS X Terminal about the current directory

### DIFF
--- a/bin/impromptu-client
+++ b/bin/impromptu-client
@@ -23,3 +23,7 @@ if [ $? != 0 ]; then
 
   generate_prompt
 fi
+
+if [ "$(type -t update_terminal_cwd 2>/dev/null)" ]; then
+  update_terminal_cwd
+fi


### PR DESCRIPTION
So that, if the setting is enabled, new and restored tabs can open in the same directory.

Fix found via thanpolas/dotfiles-1@ee74a53c843

Fixes #54
