### PR TITLE
Use a Socket Server instead of an HTTP Server

### DIFF
--- a/bin/impromptu-client
+++ b/bin/impromptu-client
@@ -28,9 +28,11 @@ IMPROMPTU_SHELL=$1"
 fi
 
 generate_prompt() {
-  curl --max-time 1 --silent \
-  -H "Accept: application/json" -H "Content-type: application/json" \
-  -X POST -d "$REQUEST" "http://localhost:$IMPROMPTU_PORT/"
+  if [ ".sock" == "${IMPROMPTU_PORT:(-5)}" ]; then
+    echo -n "$REQUEST" | nc -w 1 -U "$IMPROMPTU_PORT"
+  else
+    echo -n "$REQUEST" | nc -w 1 localhost "$IMPROMPTU_PORT"
+  fi
 }
 
 # Record the result of the generated prompt.

--- a/bin/impromptu-prompt
+++ b/bin/impromptu-prompt
@@ -60,6 +60,9 @@ if [[ ! -f $pid_file || $(ping_process) -ne 0 ]]; then
   # Start the impromptu server.
   # Ensure the server is detached from this process and save the PID.
   (
+    if [ ".sock" == "${IMPROMPTU_PORT:(-5)}" ]; then
+      rm "$IMPROMPTU_PORT" &> /dev/null
+    fi
     nohup "$IMPROMPTU_BIN/impromptu-server" $IMPROMPTU_PORT >& /dev/null &
     echo "$!" > $pid_file
   )


### PR DESCRIPTION
Impromptu just needs to pass strings into and out of the server. HTTP is overkill.

In theory, an HTTP server is able to consume and produce richer data.  The Impromptu client, though, never uses what richness the server currently produces (HTTP status codes, for example).

Pro: Slightly faster without the HTTP overhead. The transport is about twice as fast with TCP Sockets, and almost 2.5 times faster with Unix sockets.  Most of the time, though, isn't spent on transport: it's spent on calculating the prompt.  On my machine with the default prompt, this branch is ~5% faster, so it's not a huge win.

Timed with:

``` bash
$ time for i in $( seq 0 9 ); do bin/impromptu-client &> /dev/null; done
```

Con: Less extensible.

Implementation:
- Replace HTTP server with Socket server (TCP or Unix)
- Replace `curl` client with `nc` client. As written, Unix sockets only work for environments with an `nc` command that accepts a `-U` flag.
