### PR TITLE
Remove zsh-incompatible syntax, make custom socket variable explicit.

### DIFF
--- a/bin/impromptu-client
+++ b/bin/impromptu-client
@@ -28,8 +28,8 @@ IMPROMPTU_SHELL=$1"
 fi
 
 generate_prompt() {
-  if [ ".sock" == "${IMPROMPTU_PORT:(-5)}" ]; then
-    echo -n "$REQUEST" | nc -w 1 -U "$IMPROMPTU_PORT"
+  if [[ -n "$IMPROMPTU_UNIX_DOMAIN_SOCKET" ]]; then
+    echo -n "$REQUEST" | nc -w 1 -U "$IMPROMPTU_UNIX_DOMAIN_SOCKET"
   else
     echo -n "$REQUEST" | nc -w 1 localhost "$IMPROMPTU_PORT"
   fi

--- a/bin/impromptu-prompt
+++ b/bin/impromptu-prompt
@@ -60,10 +60,12 @@ if [[ ! -f $pid_file || $(ping_process) -ne 0 ]]; then
   # Start the impromptu server.
   # Ensure the server is detached from this process and save the PID.
   (
-    if [ ".sock" == "${IMPROMPTU_PORT:(-5)}" ]; then
-      rm "$IMPROMPTU_PORT" &> /dev/null
+    if [[ -n "$IMPROMPTU_UNIX_DOMAIN_SOCKET" ]]; then
+      rm "$IMPROMPTU_UNIX_DOMAIN_SOCKET" &> /dev/null
+      nohup "$IMPROMPTU_BIN/impromptu-server" $IMPROMPTU_UNIX_DOMAIN_SOCKET >& /dev/null &
+    else
+      nohup "$IMPROMPTU_BIN/impromptu-server" $IMPROMPTU_PORT >& /dev/null &
     fi
-    nohup "$IMPROMPTU_BIN/impromptu-server" $IMPROMPTU_PORT >& /dev/null &
     echo "$!" > $pid_file
   )
 

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -4,7 +4,7 @@ Impromptu = require '../lib/impromptu'
 path = require 'path'
 fs = require 'fs'
 
-port = process.argv[2] || 1624
+pathOrPort = process.argv[2] || 1624
 impromptu = new Impromptu()
 
 prompt =
@@ -61,4 +61,4 @@ server = net.createServer {allowHalfOpen: true}, (socket) ->
       type: 'env'
       data: body
 
-server.listen port
+server.listen pathOrPort


### PR DESCRIPTION
The original socket PR (#86) allowed the `IMPROMPTU_PORT` environment variable to be overridden with the path to a socket file. The test to check for a socket path used zsh-incompatible syntax `:(-5)` which caused prompt generation to fail.

This makes the use of a new socket explicit with the `IMPROMPTU_UNIX_DOMAIN_SOCKET` environment variable.
